### PR TITLE
Use DocTemplate instead of DocPage

### DIFF
--- a/config/analytics/components/ResistanceMap.js
+++ b/config/analytics/components/ResistanceMap.js
@@ -89,7 +89,7 @@ let ResistanceMap = createReactClass({
                     <HideLayerAtZoom above={4}>
                       <TableGeoJSONsLayer
                         onClickBehaviour="tooltip"
-                        onClickComponent="DocPage"
+                        onClickComponent="DocTemplate"
                         onClickComponentProps={{drug_id:drug, dynamicSize: true, path: "templates/regionCloroplethTooltip.html"}}
                         table="pf_regions"
                         geoJsonProperty="geojson"
@@ -111,7 +111,7 @@ let ResistanceMap = createReactClass({
                     <HideLayerAtZoom below={4}>
                       <TableGeoJSONsLayer
                         onClickBehaviour="tooltip"
-                        onClickComponent="DocPage"
+                        onClickComponent="DocTemplate"
                         onClickComponentProps={{drug_id:drug, dynamicSize: true, path: "templates/regionCloroplethTooltip.html"}}
                         table="pf_regions"
                         geoJsonProperty="geojson"


### PR DESCRIPTION
Fixes grey background on ResistanceMap tooltips (`doc-page` style)