### PR TITLE
Remove map numbers and fix SVG issues

### DIFF
--- a/config/analytics/components/ResistanceMap.js
+++ b/config/analytics/components/ResistanceMap.js
@@ -52,8 +52,7 @@ let ResistanceMap = createReactClass({
             {drug !== 'sites' ?
               <Typography >
                 Regions are shaded by resistance status.
-                Zoom in to see the individual sites.
-                The size of the circle indicates the number of samples collected for that site (also shown).
+                The size of the circle indicates the number of samples collected for that site.
               </Typography>
               :
               <Typography >
@@ -83,7 +82,7 @@ let ResistanceMap = createReactClass({
                 <TileLayer/>
                 {drug !== 'sites' ?
                   <FeatureGroup>
-                    <HideLayerAtZoom above={4}>
+                    <HideLayerAtZoom above={2}>
                       <TableGeoJSONsLayer
                         onClickBehaviour="tooltip"
                         onClickComponent="DocTemplate"
@@ -98,14 +97,14 @@ let ResistanceMap = createReactClass({
                         colourProperty={`${drug}resistance`}
                       />
                     </HideLayerAtZoom>
-                    <HideLayerAtZoom above={4}>
+                    <HideLayerAtZoom above={2}>
                       <TableMarkersLayer disableOnClickMarker table="sites" clusterMarkers={false}>
                         <svg style={{pointerEvents:"none", width: "4px", height: "4px", position: "absolute", left: "-2px", top: "-2px"}} viewBox="0 0 100 100">
                           <circle cx={50} cy={50} r={50} strokeWidth={0} fill="black" opacity={0.75} />
                         </svg>
                       </TableMarkersLayer>
                     </HideLayerAtZoom>
-                    <HideLayerAtZoom below={4}>
+                    <HideLayerAtZoom below={2}>
                       <TableGeoJSONsLayer
                         onClickBehaviour="tooltip"
                         onClickComponent="DocTemplate"
@@ -120,10 +119,10 @@ let ResistanceMap = createReactClass({
                         geoJsonFillOpacity={0.5}
                       />
                     </HideLayerAtZoom>
-                    <HideLayerAtZoom below={4}>
+                    <HideLayerAtZoom below={2}>
                       <TableData
                         table="sites"
-                        area={["sql_max",[200,["*", [6, "num_samples"]]]]}
+                        area={["sql_max",[25,["*", [6, "num_samples"]]]]}
                         name="name"
                         lat="lat"
                         lng="lng"

--- a/config/analytics/doc/templates/circleMapMarker.html
+++ b/config/analytics/doc/templates/circleMapMarker.html
@@ -1,6 +1,5 @@
-<svg style="overflow: visible; position: absolute" width={{radius}} height={{radius}}>
+<svg style="overflow: visible; position: absolute" width={{add 2 radius}} height={{add 2 radius}} viewBox="0 0 {{add 2 radius}} {{add 2 radius}}" preserveAspectRatio="xMidYMin slice">
   <g>
-    <circle r={{radius}} fill="{{./colour}}"/>
-    <text fill="{{constrastTextColour ./colour}}" fontSize="11px" x="0" y="0" textAnchor="middle" alignmentBaseline="middle">{{num_samples}}</text>
+    <circle r={{radius}} fill="{{./colour}}" stroke="#111111" strokeWidth="1"/>
   </g>
 </svg>


### PR DESCRIPTION
IE was making numbers mis-aligned, and I think it looks cleaner without so they are removed. I've also fixed the SVG for IE, and made the hotspots visible by default.