### PR TITLE
Prevent circle clipping.

### DIFF
--- a/config/analytics/doc/templates/circleMapMarker.html
+++ b/config/analytics/doc/templates/circleMapMarker.html
@@ -1,5 +1,3 @@
 <svg style="overflow: visible; position: absolute" width={{add 2 radius}} height={{add 2 radius}} viewBox="0 0 {{add 2 radius}} {{add 2 radius}}" preserveAspectRatio="xMidYMin slice">
-  <g>
-    <circle r={{radius}} fill="{{./colour}}" stroke="#111111" strokeWidth="1"/>
-  </g>
+  <circle r={{radius}} fill="{{./colour}}" stroke="#111111" strokeWidth="1"/>
 </svg>

--- a/config/analytics/doc/templates/circleMapMarker.html
+++ b/config/analytics/doc/templates/circleMapMarker.html
@@ -1,4 +1,4 @@
-<svg style="overflow: visible; position: absolute" width="1" height"1" preserveAspectRatio="xMidYMin slice">
-  <!-- prevents stroke clipping: --><circle r={{add radius 1}} fill-opacity="0"/>
+<svg style="overflow: visible; position: absolute" width="1" height="1" preserveAspectRatio="xMidYMin slice">
+  <!-- prevents stroke clipping: --><circle r={{add radius 1}} fillOpacity="0"/>
   <circle r={{radius}} fill="{{./colour}}" stroke="#111111" strokeWidth="1"/>
 </svg>

--- a/config/analytics/doc/templates/circleMapMarker.html
+++ b/config/analytics/doc/templates/circleMapMarker.html
@@ -1,3 +1,3 @@
-<svg style="overflow: visible; position: absolute" width={{add 2 radius}} height={{add 2 radius}} viewBox="0 0 {{add 2 radius}} {{add 2 radius}}" preserveAspectRatio="xMidYMin slice">
+<svg style="overflow: visible; position: absolute" width="1" height"1" viewBox="0 0 1 1" preserveAspectRatio="xMidYMin slice">
   <circle r={{radius}} fill="{{./colour}}" stroke="#111111" strokeWidth="1"/>
 </svg>

--- a/config/analytics/doc/templates/circleMapMarker.html
+++ b/config/analytics/doc/templates/circleMapMarker.html
@@ -1,3 +1,4 @@
-<svg style="overflow: visible; position: absolute" width="1" height"1" viewBox="0 0 1 1" preserveAspectRatio="xMidYMin slice">
+<svg style="overflow: visible; position: absolute" width="1" height"1" preserveAspectRatio="xMidYMin slice">
+  <!-- prevents stroke clipping: --><circle r={{add radius 1}} fill-opacity="0"/>
   <circle r={{radius}} fill="{{./colour}}" stroke="#111111" strokeWidth="1"/>
 </svg>


### PR DESCRIPTION
Fuxes #254

This also eliminates the invisible clickable svg square from the bottom-right quarter. Bonus!

Unfortunately, the method/trick of using an invisible circle behind the visible one is a bit of a hack (let's call it a "creative workaround", because I blame browser rendering).
An alternative might be to place the circle within ample coordinate space, by using the viewBox and various rejigs, and to solve the clickable svg problem in a different way.

(It's Friday afternoon.)